### PR TITLE
Migrate to toolchain sdk

### DIFF
--- a/.github/workflows/build_dylib.yml
+++ b/.github/workflows/build_dylib.yml
@@ -16,34 +16,34 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      SDK_VERSION: "0.1.1"
+      SDK_VERSION: "0.2.1"
       SDK_REPO: "touchHLE/common-3.0-sdk"
       
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         submodules: 'true'
 
     - name: Download SDK
       run: |
-        curl -L -o sdk.tar.gz "https://github.com/${{ env.SDK_REPO }}/releases/download/v${{ env.SDK_VERSION }}/common-3.0.sdk.tar.gz"
+        curl -L -o sdk.tar.gz "https://github.com/${{ env.SDK_REPO }}/releases/download/v${{ env.SDK_VERSION }}/common-3.0.sdk-linux-x86_64.tar.gz"
         tar xzf sdk.tar.gz
         chmod -R +x common-3.0.sdk/usr/bin/
       
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build
+      run: cmake -DCMAKE_TOOLCHAIN_FILE="common-3.0.sdk/cmake/Toolchain/common-3.0.cmake" -B build
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build
     
     - uses: actions/upload-artifact@v4
       with:
-        name: libz.1.dylib
-        path: build/libz.1.dylib
+        name: libz.1.2.3.dylib
+        path: build/libz.1.2.3.dylib
 
     - name: Create Release
       uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        files: build/libz.1.dylib
+        files: build/libz.1.2.3.dylib
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,38 +1,15 @@
 cmake_minimum_required(VERSION 3.20)
 
-# TODO: Can this be replaced with a toolchain file?
-set(CMAKE_LINK_DEPENDS_NO_SHARED TRUE)
-# Workaround for getting the build to work on Windows
-# This should be replaced with a iOS system at some point, 
-# but there is still much left to do for that to happen. 
-set(CMAKE_SYSTEM_NAME Linux)
-set(CMAKE_C_COMPILER clang)
-
-set(SDK_PATH ${CMAKE_SOURCE_DIR}/common-3.0.sdk)
-set(CMAKE_LINKER ${SDK_PATH}/usr/bin/ld)
-set(LIPO ${SDK_PATH}/usr/bin/lipo)
-
-set(CMAKE_OSX_SYSROOT ${SDK_PATH}) # Does not seem to work
-set(CMAKE_OSX_ARCHITECTURES armv6 armv7)
-set(CMAKE_OSX_DEPLOYMENT_TARGET 3.0)
-set(CMAKE_C_COMPILER_TARGET arm-apple-ios3.0)
-
-set(CMAKE_C_CREATE_SHARED_LIBRARY
-    "<CMAKE_LINKER> <LINK_FLAGS> -o <TARGET> <OBJECTS>"
-) # Force CMake to use
-# custom linker
-
-# Setting OSX Flags breaks the test on Ubuntu. Claim it works as a workaround
-# (since it does)
-set(CMAKE_C_COMPILER_WORKS TRUE)
-#
+set(CMAKE_ARCHITECTURES "armv6;armv7")
 
 project(zlib VERSION 1.2.3 LANGUAGES C)
 
-set(LIB_NAME "libz.1.dylib")
+set(LIB_NAME "libz.1.2.3.dylib")
 set(INSTALL_PATH /usr/lib)
 set(VERSION 1.2.3)
 set(COMPAT_VERSION 1.0.0)
+
+set(IMAGE_BASE 0x301f6000)
 
 if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/zlib-src")
     message(
@@ -58,80 +35,43 @@ set(ZLIB_SOURCES
     ${zlib_SOURCE_DIR}/zlib/zutil.c
 )
 
-add_compile_options(
-    -Wno-deprecated-non-prototype
-    -Wno-incompatible-sysroot
-    -Wno-expansion-to-defined
-    -fno-stack-protector
-    -isysroot
-    ${SDK_PATH} # Workardound for missing
-    # __stack_chk_*
+add_library(${LIB_NAME} SHARED ${ZLIB_SOURCES})
+
+set_target_properties(${LIB_NAME} PROPERTIES
+    OUTPUT_NAME "z.${VERSION}"
+    VERSION ${VERSION}
+    INSTALL_NAME_DIR "${INSTALL_PATH}"
+    POSITION_INDEPENDENT_CODE OFF
+    C_STANDARD 99
 )
 
-add_compile_definitions(USE_MMAP NDEBUG)
-
-# There are more idiomatic ways of setting some of these but stuff like
-# target_link_libraries was not working for some reason
-add_link_options(
-    ${SDK_PATH}/usr/lib/dylib1.o
-    -L${SDK_PATH}/usr/lib
-    -lSystem.B
-    -lgcc_s.1
-    -ios_version_min
-    ${CMAKE_OSX_DEPLOYMENT_TARGET}
-    -exported_symbols_list
-    ${zlib_SOURCE_DIR}/libz.exp
-    -dead_strip
-    -dead_strip_dylibs
-    -dylib
-    -single_module
-    -prebind
-    -dynamic
-    -twolevel_namespace
-    -twolevel_namespace_hints
-    -image_base
-    0x301f6000
-    -install_name
-    ${INSTALL_PATH}/${LIB_NAME}
+target_compile_options(${LIB_NAME} 
+    PRIVATE
+        -Wno-deprecated-non-prototype
+        -Wno-expansion-to-defined
+        -fno-stack-protector
 )
 
-set(arch_targets "")
-# Create a target for each architecture
-foreach(ARCH IN LISTS CMAKE_OSX_ARCHITECTURES)
-    set(target_name libz_${ARCH})
-    list(APPEND arch_targets ${target_name})
-    add_library(${target_name} SHARED ${ZLIB_SOURCES})
+target_compile_definitions(${LIB_NAME} 
+    PRIVATE
+        USE_MMAP
+        NDEBUG
+)
 
-    set_target_properties(
-        ${target_name}
-        PROPERTIES
-            OUTPUT_NAME "${LIB_NAME}.${ARCH}"
-            INSTALL_NAME_DIR "${INSTALL_PATH}"
-            PREFIX ""
-            SUFFIX ""
-            POSITION_INDEPENDENTCODE OFF
-            C_STANDARD 99
-    )
-
-    target_include_directories(
-        ${target_name}
-        PRIVATE ${CMAKE_SOURCE_DIR}/zlib ${SDK_PATH}/usr/include
-    )
-
-    target_compile_options(${target_name} PRIVATE -arch ${ARCH})
-
-    target_link_options(${target_name} PRIVATE -arch ${ARCH} -dylib)
-endforeach()
-
-set(lipo_inputs "")
-foreach(ARCH IN LISTS CMAKE_OSX_ARCHITECTURES)
-    list(APPEND lipo_inputs "${CMAKE_BINARY_DIR}/${LIB_NAME}.${ARCH}")
-endforeach()
-
-add_custom_target(
-    ${LIB_NAME}
-    ALL
-    COMMAND
-        ${LIPO} -create ${lipo_inputs} -output ${CMAKE_BINARY_DIR}/${LIB_NAME}
-    DEPENDS ${arch_targets}
+target_link_options(${LIB_NAME}
+    PRIVATE
+        -exported_symbols_list
+        ${zlib_SOURCE_DIR}/libz.exp
+        -dead_strip
+        -dead_strip_dylibs
+        -dylib
+        -single_module
+        -prebind
+        -dynamic
+        -twolevel_namespace
+        -twolevel_namespace_hints
+        -image_base
+        ${IMAGE_BASE}
+        -install_name
+        ${INSTALL_PATH}/${LIB_NAME}
 )

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # Building zlib dylib 
 
+## Prerequisites
+Download and extract the common-3.0.sdk:
+- Download the latest sdk from: <https://github.com/touchHLE/common-3.0-sdk/releases/latest>
+- Extract in project root
+
 ## Build Dylib
 
-`cmake -S . -B build`
+`cmake -DCMAKE_TOOLCHAIN_FILE="common-3.0.sdk/cmake/Toolchain/common-3.0.cmake" -S . -B build`
 
 `cmake --build build`
 
 ## Licensing 
 
-This SDK contains components under multiple licenses:
+This repository contains components under multiple licenses:
 
 zlib dylib binary
 - Licensed under zlib License


### PR DESCRIPTION
Move compilation to sdk with toolchain file. This allows us to have some of the necessary workarounds in a consistent source.